### PR TITLE
fix: compilation for UE5.1

### DIFF
--- a/Source/Amplitude/Amplitude.Build.cs
+++ b/Source/Amplitude/Amplitude.Build.cs
@@ -1,7 +1,6 @@
 using UnrealBuildTool;
 using System.IO;
 using System;
-using Tools.DotNETCommon;
 
 public class Amplitude : ModuleRules
 {

--- a/Source/AmplitudeEditor/AmplitudeEditor.Build.cs
+++ b/Source/AmplitudeEditor/AmplitudeEditor.Build.cs
@@ -3,7 +3,6 @@
 using UnrealBuildTool;
 using System.IO;
 using System;
-using Tools.DotNETCommon;
 
 public class AmplitudeEditor : ModuleRules
 {
@@ -21,7 +20,8 @@ public class AmplitudeEditor : ModuleRules
         "Analytics",
         "AnalyticsVisualEditing",
         "Engine",
-        "Projects"
+        "Projects",
+        "DeveloperSettings"
       }
       );
 


### PR DESCRIPTION
### Summary

Fixed compilation for UE5.1
- removed deprecated C# library: `using Tools.DotNETCommon;`.
- added new module dependency for settings class `DeveloperSettings`.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Unreal/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Yes (only for Unreal Engine version 4.25 or earlier)
